### PR TITLE
Fixed is_verified update

### DIFF
--- a/laravel-app/app/Observers/isVerifiedObserver.php
+++ b/laravel-app/app/Observers/isVerifiedObserver.php
@@ -7,14 +7,6 @@ use App\Models\User;
 class isVerifiedObserver
 {
     /**
-     * Handle the User "created" event.
-     */
-    public function created(User $user): void
-    {
-        //
-    }
-
-    /**
      * Handle the User "updated" event.
      */
     public function updating(User $user): void
@@ -22,29 +14,5 @@ class isVerifiedObserver
         if ($user->isDirty('email_verified_at') && $user->email_verified_at !== null) {
             $user->is_verified = true;
         }
-    }
-
-    /**
-     * Handle the User "deleted" event.
-     */
-    public function deleted(User $user): void
-    {
-        //
-    }
-
-    /**
-     * Handle the User "restored" event.
-     */
-    public function restored(User $user): void
-    {
-        //
-    }
-
-    /**
-     * Handle the User "force deleted" event.
-     */
-    public function forceDeleted(User $user): void
-    {
-        //
     }
 }

--- a/laravel-app/app/Observers/isVerifiedObserver.php
+++ b/laravel-app/app/Observers/isVerifiedObserver.php
@@ -19,9 +19,7 @@ class isVerifiedObserver
      */
     public function updating(User $user): void
     {
-        // Check if the email_verified_at attribute is dirty (changed)
         if ($user->isDirty('email_verified_at') && $user->email_verified_at !== null) {
-            // Update the is_verified attribute to true
             $user->is_verified = true;
         }
     }

--- a/laravel-app/app/Observers/isVerifiedObserver.php
+++ b/laravel-app/app/Observers/isVerifiedObserver.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+
+class isVerifiedObserver
+{
+    /**
+     * Handle the User "created" event.
+     */
+    public function created(User $user): void
+    {
+        //
+    }
+
+    /**
+     * Handle the User "updated" event.
+     */
+    public function updating(User $user): void
+    {
+        // Check if the email_verified_at attribute is dirty (changed)
+        if ($user->isDirty('email_verified_at') && $user->email_verified_at !== null) {
+            // Update the is_verified attribute to true
+            $user->is_verified = true;
+        }
+    }
+
+    /**
+     * Handle the User "deleted" event.
+     */
+    public function deleted(User $user): void
+    {
+        //
+    }
+
+    /**
+     * Handle the User "restored" event.
+     */
+    public function restored(User $user): void
+    {
+        //
+    }
+
+    /**
+     * Handle the User "force deleted" event.
+     */
+    public function forceDeleted(User $user): void
+    {
+        //
+    }
+}

--- a/laravel-app/app/Providers/AppServiceProvider.php
+++ b/laravel-app/app/Providers/AppServiceProvider.php
@@ -2,23 +2,17 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\isVerifiedObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
     /**
-     * Register any application services.
-     */
-    public function register(): void
-    {
-        //
-    }
-
-    /**
      * Bootstrap any application services.
      */
     public function boot(): void
     {
-        //
+        User::observe(isVerifiedObserver::class);
     }
 }

--- a/laravel-app/app/Services/UserVerificationService.php
+++ b/laravel-app/app/Services/UserVerificationService.php
@@ -8,7 +8,7 @@ class UserVerificationService
 {
     public function isUserVerified($user)
     {
-        if (!$user->email_verified_at) {
+        if (!$user->is_verified) {
             auth()->logout();
             throw ValidationException::withMessages(['email' => 'Your account is not verified.']);
         }


### PR DESCRIPTION
**OVERVIEW**
- Fixed is_verified column in users that updates whenever email_verified_at updates
- Reverted back the logic that checks whether the user is verified or not
- Added an Observer Event to observe changes in the users table

**NOTES**
- The is_verified column updates when email_verified_at updates. Meaning, the user clicked the verification link. This will be used to determine whether a user is email verified or not.