### PR TITLE
Added specific profile show and edit restriction

### DIFF
--- a/laravel-app/app/Http/Controllers/ProfileController.php
+++ b/laravel-app/app/Http/Controllers/ProfileController.php
@@ -65,4 +65,13 @@ class ProfileController extends Controller
             return redirect()->back()->withErrors($error);
         }
     }
+
+    /**
+     * Show specific user profile.
+     */
+    public function show(int $userId): View
+    {
+        $user = User::whereId($userId)->first();
+        return view('profile.show', compact('user'));
+    }
 }

--- a/laravel-app/app/Policies/UserProfilePolicy.php
+++ b/laravel-app/app/Policies/UserProfilePolicy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class UserProfilePolicy
+{
+    /**
+     * Determine whether the user can update the profileUser.
+     */
+    public function update(User $user, User $profileUser): bool
+    {
+        return $user->id === $profileUser->id;
+    }
+}

--- a/laravel-app/app/Providers/AuthServiceProvider.php
+++ b/laravel-app/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -21,6 +21,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        $this->registerPolicies();
+
+        Gate::define('user-profile', 'App\Policies\UserProfilePolicy');
     }
 }

--- a/laravel-app/resources/views/profile/show.blade.php
+++ b/laravel-app/resources/views/profile/show.blade.php
@@ -1,0 +1,82 @@
+@extends('layouts.app')
+
+@section('content')
+
+@include('partials._header')
+<div id="page-content">
+	<div class="p-3">
+		<div class="row justify-content-center">
+			<div class="col-md-4 text-center">
+				<img class="img-fluid w-50" src="{{ asset('assets/images/microblog-logo.png') }}" alt="Microblog Logo">
+			</div>
+			<div class="col-6 pt-1">
+				<div class="row">
+					<div class="col">
+						<label>Name</label>
+						<p class="fw-bold">{{ $user->user_information->first_name . ' ' . $user->user_information->middle_name . ' ' . $user->user_information->last_name}} </p>
+					</div>
+				</div>
+				<div class="row">
+					<label>Username</label>
+					<p class="fw-bold">{{ $user->username }}</p>
+				</div>
+				<div class="row">
+					<label>Email</label>
+					<p class="fw-bold">{{ $user->email}}</p>
+				</div>
+				<div class="row">
+					<label>Bio</label>
+					<p class="fw-bold">{{ $user->user_information->bio }}</p>
+				</div>
+				<div class="row">
+					<label>Gender</label>
+					<p class="fw-bold">{{ $user->user_information->gender }}</p>
+				</div>
+				<div class="row">
+					<div class="col">
+						<label>User created at</label>
+						<p class="fw-bold">{{ $user->created_at->format('F j, Y') }}</p>
+					</div>
+					<div class="col">
+						@if ($user->updated_at)
+						<label>Updated at</label>
+							<p class="fw-bold">{{ $user->updated_at->format('F j, Y') }}</p>
+						@endif
+					</div>
+				</div>
+				<div class="card m-1 mb-3">
+					<div class="card-body">
+						<div class="row">
+							<div class="col offset-1">
+								<label>Followers</label>
+								<p class="fw-bold mt-1">{{ '0' }}</p>
+							</div>
+							<div class="col">
+								<label>Posts</label>
+								<p class="fw-bold mt-1">{{ '0' }}</p>
+							</div>
+							<div class="col">
+								<label>Likes</label>
+								<p class="fw-bold mt-1">{{ '0' }}</p>
+							</div>
+						</div>
+					</div>
+				</div>
+				@can('edit', $user)
+					<div class="row justify-content-center">
+						<div class="col-3">
+							<a href="{{ route('profile.edit', $user->id) }}" class="btn btn-secondary">Edit Information</a>
+						</div>
+					</div>
+				@endcan
+			</div>
+		</div>
+	</div>
+	@foreach ($user->posts as $post)
+		<x-post-component :post="$post" :user="$user"/>
+	@endforeach
+</div>
+
+@include('partials._footer')
+
+@endsection

--- a/laravel-app/resources/views/search/results.blade.php
+++ b/laravel-app/resources/views/search/results.blade.php
@@ -18,7 +18,7 @@
 							<div class="card-body">
 								<div class="row">
 									<div class="col text-start">
-										<a class="text-dark" href="#">
+										<a class="text-dark" href="{{ route('profile.show', $result->id) }}">
 											<img src="{{ asset('assets/images/microblog-logo-iconx30.png') }}" alt="Image">
 											{{ $result->username }}
 										</a>

--- a/laravel-app/routes/web.php
+++ b/laravel-app/routes/web.php
@@ -28,7 +28,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/home', [HomeController::class, 'index'])->name('home');
     Route::post('/logout', [HomeController::class, 'logout'])->name('logout');
     Route::resource('/post', PostController::class, ['only' => ['create', 'store', 'show']]);
-    Route::resource('/profile', ProfileController::class, ['only' => ['index', 'edit', 'update']]);
+    Route::resource('/profile', ProfileController::class, ['only' => ['index', 'edit', 'update', 'show']]);
     Route::post('/posts/{post}/like', [LikeController::class, 'like'])->name('post.like');
     Route::delete('/posts/{post}/unlike', [LikeController::class, 'unlike'])->name('post.unlike');
     Route::get('/search', [SearchController::class, 'search'])->name('search');


### PR DESCRIPTION
### OVERVIEW

- added policy for editing user profiles
- registered the policy
- created show blade for displaying specific instance of user profiles

### NOTES

- profile edit can only be done on the logged in user profile
- no edit button and edit route for other profiles shown
- entering id of other user to the link-edit will redirect to your own profile edit

### SNIPPETS
Viewing profile of the owner
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/22072304-0e0b-4b89-aa19-5da8f2a6c36e)
Viewing profile of other user
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/3ab19bf4-7f41-4cfc-b356-5a2e1089d20a)
Link to your own edit profile
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/81ef9b87-9856-44cb-b90c-a74c852b6a90)
Entering other user id to the link
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/fc26f29b-005f-4910-8c25-00a65cdab527)
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/21fe44ba-7037-4690-bbee-e00e8b4401d6)
