### PR TITLE
fixed policy naming of edit button in profile

### DIFF
--- a/laravel-app/app/Providers/AuthServiceProvider.php
+++ b/laravel-app/app/Providers/AuthServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use App\Models\UserPost;
 use App\Policies\UserPostPolicy;
+use App\Policies\UserProfilePolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -25,7 +26,7 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        Gate::define('user-profile', 'App\Policies\UserProfilePolicy');
+        Gate::define('update-user-profile', [UserProfilePolicy::class, 'update']);
         Gate::define('user-post', 'App\Policies\UserPostPolicy');
     }
 }

--- a/laravel-app/resources/views/profile/show.blade.php
+++ b/laravel-app/resources/views/profile/show.blade.php
@@ -82,10 +82,10 @@
 						</div>
 					</div>
 				</div>
-				@can('edit', $user)
+				@can('update-user-profile', $user)
 					<div class="row justify-content-center">
 						<div class="col-3">
-							<a href="{{ route('profile.edit', $user->id) }}" class="btn btn-secondary">Edit Information</a>
+							<a href="{{ route('profile.edit', $user->id) }}" class="btn btn-secondary">Update Information</a>
 						</div>
 					</div>
 				@endcan


### PR DESCRIPTION
### OVERVIEW

- modified naming of policy in edit profile
- fixed the name policy in show blade

### NOTES

- the update button now shows for the owner of the profile

### SNIPPETS

update button in profile page of owner
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/d719d6ef-da93-4231-bd1e-216c07bb9868)

no access for edit button in other profile viewing
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/7fae6125-0f7e-40f2-98e6-4a1fa0bb0f24)
