### PR TITLE
added requirements for password in user creation

### DIFF
--- a/laravel-app/app/Http/Requests/CreateUserRequest.php
+++ b/laravel-app/app/Http/Requests/CreateUserRequest.php
@@ -15,7 +15,13 @@ class CreateUserRequest extends FormRequest
     {
         return [
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'password' => [
+                'required',
+                'string',
+                'min:8',
+                'confirmed',
+                'regex: /^(?=.*[A-Za-z])(?=.*[A-Z])(?=.*[a-z])(?=.*[!@#$%^&*()_+{}[\]:;<>,.?~\\-]).{8,}$/',
+            ],
             'username' => ['required', 'string', 'max:255', 'unique:users'],
             'first_name' => ['required', 'string', 'max:255'],
             'last_name' => ['required', 'string', 'max:255'],
@@ -40,6 +46,7 @@ class CreateUserRequest extends FormRequest
             'password.required' => 'The password field is required.',
             'password.min' => 'The password must be at least :min characters.',
             'password.confirmed' => 'The password confirmation does not match.',
+            'password.regex' => 'The password must contain at least one uppercase letter, one lowercase letter, one special character, and be at least 8 characters long.',
         ];
     }
 

--- a/laravel-app/tests/Unit/RegisterControllerTest.php
+++ b/laravel-app/tests/Unit/RegisterControllerTest.php
@@ -22,7 +22,7 @@ class RegisterControllerTest extends TestCase
             'last_name' => $this->faker->lastName,
             'username' => $this->faker->userName,
             'email' => $this->faker->unique()->safeEmail,
-            'password' => 'secret123',
+            'password' => 'Secret123@Pass',
             'password_confirmation' => 'Secret123@Pass',
         ];
 

--- a/laravel-app/tests/Unit/RegisterControllerTest.php
+++ b/laravel-app/tests/Unit/RegisterControllerTest.php
@@ -23,7 +23,7 @@ class RegisterControllerTest extends TestCase
             'username' => $this->faker->userName,
             'email' => $this->faker->unique()->safeEmail,
             'password' => 'secret123',
-            'password_confirmation' => 'secret123',
+            'password_confirmation' => 'Secret123@Pass',
         ];
 
         $request = new CreateUserRequest();


### PR DESCRIPTION
### OVERVIEW

- added regex requirement for the password in user registration blade

### NOTES

- the password now requires to have at least one uppercase letter, one lowercase letter, one special character, and be at least 8 characters long when creating a new account.

### SNIPPETS

![image](https://github.com/bpocrafael/microblog-project/assets/144191038/c75007b5-f117-4144-8ac9-d55847f47a4f)

