### PR TITLE
added pagination for posts, search, and profile

### DIFF
--- a/laravel-app/app/Http/Controllers/HomeController.php
+++ b/laravel-app/app/Http/Controllers/HomeController.php
@@ -8,20 +8,17 @@ use App\Models\User;
 
 class HomeController extends Controller
 {
-    /**
-     * Show the application dashboard.
-     */
     public function index(): View
     {
         /** @var User $user */
         $user = auth()->user();
-        $posts = $user->posts;
+        $posts = $user->posts()
+            ->orderBy('created_at', 'desc')
+            ->paginate(4);
+
         return view('home', compact('user', 'posts'));
     }
 
-    /**
-     * Logout the user.
-     */
     public function logout(): RedirectResponse
     {
         auth()->logout();

--- a/laravel-app/app/Http/Controllers/PostController.php
+++ b/laravel-app/app/Http/Controllers/PostController.php
@@ -18,30 +18,12 @@ class PostController extends Controller
         $this->postService = $postService;
     }
 
-    /*
-    * View all instances of posts in home page.
-    */
-    public function index(): View
-    {
-        /** @var User $user */
-        $user = auth()->user();
-        $posts = $user->posts()->orderBy('created_at', 'desc')->get();
-
-        return view('home', compact('user', 'posts'));
-    }
-
-    /**
-     * Show create post page.
-     */
     public function create(): View
     {
         $user = auth()->user();
         return view('post.create', compact('user'));
     }
 
-    /**
-     * Save post content as new post.
-     */
     public function store(UserPostRequest $request): RedirectResponse
     {
         /** @var User $user */
@@ -59,25 +41,16 @@ class PostController extends Controller
         return back()->with('error', 'Failed to create post');
     }
 
-    /*
-    * Display specific post.
-    */
     public function show(UserPost $post): View
     {
         return view('post.show', ['post' => $post]);
     }
 
-    /*
-    * Display edit post.
-    */
     public function edit(UserPost $post): View
     {
         return view('post.edit', ['post' => $post]);
     }
 
-    /*
-    * Update post
-    */
     public function update(UserPostRequest $request, UserPost $post): RedirectResponse
     {
         $validatedData = $request->validated();

--- a/laravel-app/app/Http/Controllers/ProfileController.php
+++ b/laravel-app/app/Http/Controllers/ProfileController.php
@@ -50,9 +50,11 @@ class ProfileController extends Controller
     {
         $user = User::with('posts.likes')->find($userId);
 
-        $posts = $user->posts()
-            ->orderBy('created_at', 'desc')
-            ->paginate(4);
+        if ($user !== null){
+            $posts = $user->posts()
+                ->orderBy('created_at', 'desc')
+                ->paginate(4);
+        }
 
         if (!$user) {
             $error = ['error' => 'No user with that id found.'];

--- a/laravel-app/app/Http/Controllers/ProfileController.php
+++ b/laravel-app/app/Http/Controllers/ProfileController.php
@@ -13,17 +13,11 @@ class ProfileController extends Controller
 {
     protected ProfileService $userService;
 
-    /**
-     * Create a new controller instance.
-     */
     public function __construct(ProfileService $userService)
     {
         $this->userService = $userService;
     }
 
-    /**
-     * Show the profile edit page.
-     */
     public function edit(): View
     {
         /** @var User $user */
@@ -31,9 +25,6 @@ class ProfileController extends Controller
         return view('profile.edit', compact('user'));
     }
 
-    /**
-     * Update the profile.
-     */
     public function update(UpdateProfileRequest $request): RedirectResponse
     {
         /** @var User $user */
@@ -55,12 +46,13 @@ class ProfileController extends Controller
         }
     }
 
-    /**
-     * Show specific user profile.
-     */
     public function show(int $userId): RedirectResponse|View
     {
         $user = User::with('posts.likes')->find($userId);
+
+        $posts = $user->posts()
+            ->orderBy('created_at', 'desc')
+            ->paginate(4);
 
         if (!$user) {
             $error = ['error' => 'No user with that id found.'];
@@ -74,6 +66,7 @@ class ProfileController extends Controller
         return view('profile.show', [
             'user' => $user,
             'likesCount' => $likesCount,
+            'posts' => $posts,
         ]);
     }
 }

--- a/laravel-app/app/Http/Controllers/SearchController.php
+++ b/laravel-app/app/Http/Controllers/SearchController.php
@@ -10,22 +10,16 @@ class SearchController extends Controller
 {
     protected SearchService $searchService;
 
-    /**
-     * Make an instance of SearchController.
-     */
     public function __construct(SearchService $searchService)
     {
         $this->searchService = $searchService;
     }
 
-    /**
-     * To search for user using keywords.
-     */
     public function search(SearchRequest $request): View
     {
         $query = $request->input('query');
 
-        $results = $this->searchService->searchUser($query);
+        $results = $this->searchService->searchUser($query)->paginate(4);
 
         return view('search.results', ['results' => $results, 'query' => $query]);
     }

--- a/laravel-app/app/Interfaces/SearchServiceInterface.php
+++ b/laravel-app/app/Interfaces/SearchServiceInterface.php
@@ -2,9 +2,9 @@
 
 namespace App\Interfaces;
 
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 interface SearchServiceInterface
 {
-    public function searchUser(string $query): Collection;
+    public function searchUser(string $query): Builder;
 }

--- a/laravel-app/app/Services/SearchService.php
+++ b/laravel-app/app/Services/SearchService.php
@@ -4,7 +4,7 @@ namespace App\Services;
 
 use App\Interfaces\SearchServiceInterface;
 use App\Models\User;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 class SearchService implements SearchServiceInterface
 {
@@ -12,8 +12,8 @@ class SearchService implements SearchServiceInterface
      * To search the User table using the Eloquent of matching results.
      * @return Collection<User>
      */
-    public function searchUser(String $query): Collection
+    public function searchUser(String $query): Builder
     {
-        return User::where('username', 'like', '%' . $query . '%')->get();
+        return User::where('username', 'like', '%' . $query . '%');
     }
 }

--- a/laravel-app/app/Services/SearchService.php
+++ b/laravel-app/app/Services/SearchService.php
@@ -10,7 +10,6 @@ class SearchService implements SearchServiceInterface
 {
     /**
      * To search the User table using the Eloquent of matching results.
-     * @return Collection<User>
      */
     public function searchUser(String $query): Builder
     {

--- a/laravel-app/resources/views/home.blade.php
+++ b/laravel-app/resources/views/home.blade.php
@@ -47,6 +47,7 @@
             <x-post-component :post="$post" :user=$user />
         @endforeach
 
+        {{ $posts->links('partials._pagination') }}
     </div>
 </div>
 @include('partials._footer')

--- a/laravel-app/resources/views/partials/_pagination.blade.php
+++ b/laravel-app/resources/views/partials/_pagination.blade.php
@@ -1,0 +1,37 @@
+<ul class="pagination justify-content-center m-5">
+    @if ($paginator->lastPage() > 1)
+        @if ($paginator->onFirstPage())
+            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+        @else
+            <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}">&laquo;</a></li>
+        @endif
+
+        @foreach ($elements as $element)
+            @if (is_string($element))
+                <li class="page-item disabled"><span class="page-link">{{ $element }}</span></li>
+            @endif
+
+            @if (is_array($element))
+                @foreach ($element as $page => $url)
+                    @if ($page == $paginator->currentPage())
+                        <li class="page-item active">
+                            <span class="page-link">{{ $page }}</span>
+                        </li>
+                    @else
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $url }}">{{ $page }}</a>
+                        </li>
+                    @endif
+                @endforeach
+            @endif
+        @endforeach
+
+        @if ($paginator->hasMorePages())
+            <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}">&raquo;</a></li>
+        @else
+            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+        @endif
+    @else
+        <p>End of contents</p>
+    @endif
+</ul>

--- a/laravel-app/resources/views/profile/show.blade.php
+++ b/laravel-app/resources/views/profile/show.blade.php
@@ -100,9 +100,11 @@
 			</div>
 		</div>
 	</div>
-	@foreach ($user->posts as $post)
+	@foreach ($posts as $post)
 		<x-post-component :post="$post" :user="$user"/>
 	@endforeach
+
+	{{ $posts->links('partials._pagination') }}
 </div>
 
 @include('partials._footer')

--- a/laravel-app/resources/views/search/results.blade.php
+++ b/laravel-app/resources/views/search/results.blade.php
@@ -13,12 +13,12 @@
 		<div class="row justify-content-center text-center">
 			<div class="col-md-6">
 				<div class="mb-4">
-					<h4>Microblog User Results for "{{ $query }}"</h4>
+					<h4>Microblog User results for "{{ $query }}"</h4>
 				</div>
 
 				@if ($results->count() > 0)
 					@foreach ($results as $result)
-						<div class="card">
+						<div class="card m-2">
 							<div class="card-body">
 								<div class="row">
 									<div class="col text-start">
@@ -48,6 +48,7 @@
 							</div>
 						</div>
 					@endforeach
+					{{ $results->links('partials._pagination') }}
 				@else
 					<div class="row">
 						<div class="col">


### PR DESCRIPTION
### OVERVIEW

- modified controller for home, search, and profile to paginate items
- added pagination links to the blades
- added pagination partial blade
- removed unnecessary comments

### NOTES

- queries or items are paginated to 4 items, if items are only 1 page pagination links are not displayed

### SNIPPETS

home page posts
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/353f7b1d-cd2e-4dd6-a063-f7a2b88f3662)
profile page posts 2nd page
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/62023a71-015a-43f2-930f-39c84de4aefc)
search result
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/5ddf9cc7-668f-41d5-88ea-60c105fa579f)
1 page items
![image](https://github.com/bpocrafael/microblog-project/assets/144191038/7e48b04d-ae72-424c-bd75-0e231d829871)

