### PR TITLE
fix/ post comment bugfix

### DIFF
--- a/laravel-app/app/Policies/PostCommentPolicy.php
+++ b/laravel-app/app/Policies/PostCommentPolicy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\PostComment;
+use App\Models\User;
+
+class PostCommentPolicy
+{
+    /**
+     * Determines whether the user can delete his/her own comment.
+     */
+    public function delete(User $user, PostComment $comments): bool
+    {
+        return $user->id === $comments->user_id;
+    }
+}

--- a/laravel-app/resources/views/components/comment.blade.php
+++ b/laravel-app/resources/views/components/comment.blade.php
@@ -21,6 +21,7 @@
                             <div class="card-footer fst-italic">{{ $comments->created_at->format('F j, Y h:m A') }}
                             </div>
                         </div>
+                        @can('delete', $comments)
                         <form method="POST" action="{{ route('comment.delete', $comments) }}">
                             @csrf
                             @method('DELETE')
@@ -28,6 +29,7 @@
                                 <button type="submit" class="btn btn-sm btn-danger">Delete</button>
                             </div>
                         </form>
+                        @endcan
                     </div>
                 </div>
         </div>


### PR DESCRIPTION
### OVERVIEW
Fixed a comment by adding filter on deleting one's comment. 
Only owned comments can be deleted.

### SNIPPETS
First image shows own comment with a delete option.
Second is another persons comment with no delete option.
![Screenshot 2023-10-16 001925](https://github.com/bpocrafael/microblog-project/assets/144191092/b8ae132c-950b-45e6-b75d-142477b0af3f)
![image](https://github.com/bpocrafael/microblog-project/assets/144191092/69c61eb2-3178-491c-9db7-ac7b64972a23)

